### PR TITLE
Pass organization name to CSW records

### DIFF
--- a/bin/ckan_pycsw.py
+++ b/bin/ckan_pycsw.py
@@ -64,7 +64,7 @@ def load(pycsw_config, ckan_url):
 
     log.info('Started gathering CKAN datasets identifiers: {0}'.format(str(datetime.datetime.now())))
 
-    query = 'api/search/dataset?qjson={"fl":"id,metadata_modified,extras_harvest_object_id,extras_metadata_source", "q":"harvest_object_id:[\\"\\" TO *]", "limit":1000, "start":%s}'
+    query = 'api/search/dataset?qjson={"fl":"id,metadata_modified,extras_harvest_object_id,extras_metadata_source,organization", "q":"harvest_object_id:[\\"\\" TO *]", "limit":1000, "start":%s}'
 
     start = 0
 
@@ -84,7 +84,8 @@ def load(pycsw_config, ckan_url):
             gathered_records[result['id']] = {
                 'metadata_modified': result['metadata_modified'],
                 'harvest_object_id': result['extras']['harvest_object_id'],
-                'source': result['extras'].get('metadata_source')
+                'source': result['extras'].get('metadata_source'),
+                'organization': result['organization'],
             }
 
         start = start + 1000
@@ -188,6 +189,7 @@ def get_record(context, repo, ckan_url, ckan_id, ckan_info):
     if not record.identifier:
         record.identifier = ckan_id
     record.ckan_id = ckan_id
+    record.organization = ckan_info['organization']
     record.ckan_modified = ckan_info['metadata_modified']
 
     return record


### PR DESCRIPTION
PyCSW already has a column and is ready to accept organization under the namespace `apiso:OrganisationName`. I modified the CKAN API request used by the loader to also pull the CKAN organization metadata from each record and pass it to PyCSW.

Here's an example query for how to query organizations:

```xml
<?xml version="1.0"?>
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" outputSchema="http://www.opengis.net/cat/csw/2.0.2" outputFormat="application/xml" version="2.0.2" service="CSW" resultType="results" startPosition="10" maxRecords="100" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
<csw:Query typeNames="csw:Record">
  <csw:ElementSetName>summary</csw:ElementSetName>
  <csw:Constraint version="1.1.0">
    <ogc:Filter>
      <ogc:PropertyIsEqualTo>
        <ogc:PropertyName>apiso:OrganisationName</ogc:PropertyName>
        <ogc:Literal>aoos</ogc:Literal>
      </ogc:PropertyIsEqualTo>
    </ogc:Filter>
  </csw:Constraint>
</csw:Query>
</csw:GetRecords>
```

After this PR is pulled and integrated.